### PR TITLE
implements issue #12 only build push commits on master.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: required
 language: cpp
 dist: trusty
+branches:
+  only:
+    - master
 services:
   - docker
 before_script:


### PR DESCRIPTION
This pull request adds a safelist entry in .travis.yml to restrict building of push commits. For now only the master branch will be build when a commit is pushed.